### PR TITLE
処理を動的に実行させるため、抽象クラスProcessor.phpと子クラス2つを作成。

### DIFF
--- a/src/src/lib/DomainViewProcessor.php
+++ b/src/src/lib/DomainViewProcessor.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace WikiLogs;
+
+use PDO;
+
+class DomainViewProcessor extends Processor
+{
+  public function execute(PDO $pdo) {}
+}

--- a/src/src/lib/LogAnalyses.php
+++ b/src/src/lib/LogAnalyses.php
@@ -5,8 +5,14 @@ namespace WikiLogs;
 use PDO;
 use PDOException;
 use Dotenv;
+use WikiLogs\Processor;
+use WikiLogs\ViewCountProcessor;
+use WikiLogs\DomainViewProcessor;
 
 require_once __DIR__ . '/../../vendor/autoload.php';
+require_once __DIR__ . '/Processor.php';
+require_once __DIR__ . '/ViewCountProcessor.php';
+require_once __DIR__ . '/DomainViewProcessor.php';
 
 class LogAnalyses
 {
@@ -20,9 +26,11 @@ class LogAnalyses
       return null;
     }
     $this->displayStartMessage();
-    $result = $this->selectNumber();
+    $selectNumber = $this->selectNumber();
     // 選択された番号に応じて処理を分岐
-    return $result;
+    $processor = $this->getProcessor($selectNumber);
+    $this->execute($processor, $pdo);
+    return 1;
   }
 
   public function connectDb()
@@ -66,12 +74,27 @@ class LogAnalyses
     return true;
   }
 
-
   private function isOneOrTwo(int $input): bool
   {
     if ($input === 1 || $input === 2) {
       return true;
     }
     return false;
+  }
+
+  // 入力値に応じて異なる表示処理を行うProcessorクラスをそれぞれ生成
+  private function getProcessor(int $selectNumber): Processor
+  {
+    switch ($selectNumber) {
+      case 1:
+        return new ViewCountProcessor();
+      case 2:
+        return new DomainViewProcessor();
+    }
+  }
+
+  private function execute(Processor $processor, PDO $pdo): void
+  {
+    $processor->execute($pdo);
   }
 }

--- a/src/src/lib/Processor.php
+++ b/src/src/lib/Processor.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace WikiLogs;
+
+use PDO;
+
+abstract class Processor
+{
+  abstract function execute(PDO $pdo);
+}

--- a/src/src/lib/ViewCountProcessor.php
+++ b/src/src/lib/ViewCountProcessor.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace WikiLogs;
+
+use PDO;
+
+class ViewCountProcessor extends Processor
+{
+  public function execute(PDO $pdo) {}
+}

--- a/src/src/tests/LogAnalysesTest.php
+++ b/src/src/tests/LogAnalysesTest.php
@@ -6,7 +6,6 @@ use PHPUnit\Framework\TestCase;
 use WikiLogs\LogAnalyses;
 use Dotenv;
 use PDO;
-use PDOStatement;
 
 require_once __DIR__ . '/../../vendor/autoload.php';
 require_once(__DIR__ . '/../lib/LogAnalyses.php');


### PR DESCRIPTION
1.記事の中から、指定した数ほど閲覧数の多い記事を表示する処理
2:ドメインごとに最も多い閲覧数を表示する処理

上記２種類の表示処理を入力した値(1もしくは2)に応じて動的に実行させるため、下記をそれぞれ作成しました。
■抽象クラス
Processor.php
■子クラス
・ViewCountProcessor.php
今後、記事の中から、指定した数ほど閲覧数の多い記事を表示する処理を実装
・DomainViewProcessor.php
今後、ドメインごとに最も多い閲覧数を表示する処理を実装

LogAnalyses.phpでは、start()内のgetProcessor()にて、上記２つの子クラスを入力された番号に応じて生成し、
execute()にて子クラスのexecute()を使用して今後上記2種類の表示処理を実装します。
*動的に処理を実行できるようにしているため、今後、表示処理が増えたとしてもProcessorクラスの子クラスを新たに作成するなど、仕様変更による影響を最小限に抑えることが可能となっております。