### PR TITLE
閲覧数の最も多い記事のﾄﾞﾒｲﾝ名、ﾍﾟｰｼﾞﾀｲﾄﾙ、総閲覧数を表示できるようにしました。

### DIFF
--- a/src/phpunit.xml
+++ b/src/phpunit.xml
@@ -2,7 +2,9 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" bootstrap="vendor/autoload.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.2/phpunit.xsd" cacheDirectory=".phpunit.cache">
   <testsuites>
     <testsuite name="Tests">
-      <directory>src/tests/</directory>
+      <!-- <directory>src/tests/</directory> -->
+      <!-- <file>src/tests/ViewCountProcessorTest.php</file> -->
+      <file>src/tests/LogAnalysesTest.php</file>
     </testsuite>
   </testsuites>
 </phpunit>

--- a/src/src/lib/LogAnalyses.php
+++ b/src/src/lib/LogAnalyses.php
@@ -16,7 +16,7 @@ require_once __DIR__ . '/DomainViewProcessor.php';
 
 class LogAnalyses
 {
-  public function start()
+  public function start(): bool
   {
     try {
       $pdo = $this->connectDb();
@@ -30,10 +30,10 @@ class LogAnalyses
     // 選択された番号に応じて処理を分岐
     $processor = $this->getProcessor($selectNumber);
     $this->execute($processor, $pdo);
-    return 1;
+    return true;
   }
 
-  public function connectDb()
+  protected function connectDb(): PDO
   {
     $dotenv = Dotenv\Dotenv::createImmutable(__DIR__);
     $dotenv->load();

--- a/src/src/lib/ViewCountProcessor.php
+++ b/src/src/lib/ViewCountProcessor.php
@@ -6,5 +6,40 @@ use PDO;
 
 class ViewCountProcessor extends Processor
 {
-  public function execute(PDO $pdo) {}
+  public function execute(PDO $pdo): void
+  {
+    $articleCount = $this->getArticleCount();
+    $statement = $pdo->prepare('SELECT * FROM page_views ORDER BY page_views DESC LIMIT :articleCount');
+    $statement->bindParam(':articleCount', $articleCount, PDO::PARAM_INT);
+    $statement->execute();
+    while ($rows = $statement->fetch(PDO::FETCH_ASSOC)) {
+      foreach ($rows as $row) {
+        echo $row . PHP_EOL;
+      }
+      echo '------------------------------' . PHP_EOL;
+    }
+  }
+
+  // 表示する記事の数を標準入力より取得
+  private function getArticleCount(): int
+  {
+    while (true) {
+      echo '表示させたい記事数の値(整数)を入力してください。' . PHP_EOL;
+      echo '------------------------------' . PHP_EOL;
+      $ArticleCount = trim(fgets(STDIN));
+      if (is_numeric($ArticleCount) && $this->isNotFloat($ArticleCount)) {
+        break;
+      }
+      echo 'Error:1以上の整数以外が入力されております。' . PHP_EOL;
+    }
+    return $ArticleCount;
+  }
+
+  private function isNotFloat($input): bool
+  {
+    if (strpos($input, '.') !== false) {
+      return false;
+    }
+    return true;
+  }
 }

--- a/src/src/tests/LogAnalysesTest.php
+++ b/src/src/tests/LogAnalysesTest.php
@@ -4,46 +4,99 @@ namespace WikiLogs\Tests;
 
 use PHPUnit\Framework\TestCase;
 use WikiLogs\LogAnalyses;
+use WikiLogs\ViewCountProcessor;
+use WikiLogs\DomainViewProcessor;
 use Dotenv;
 use PDO;
+use ReflectionClass;
 
 require_once __DIR__ . '/../../vendor/autoload.php';
 require_once(__DIR__ . '/../lib/LogAnalyses.php');
+require_once(__DIR__ . '/../lib/ViewCountProcessor.php');
+require_once(__DIR__ . '/../lib/DomainViewProcessor.php');
 
 class LogAnalysesTest extends TestCase
 {
+  // PDOオブジェクトを格納するプロパティ
+  private $pdo;
+  // LogAnalysesオブジェクトを格納するプロパティ
+  private $logAnalyses;
+
   public function setUp(): void
   {
+    parent::setUp();
     // .envファイルのロード
     $dotenv = Dotenv\Dotenv::createImmutable(dirname(__DIR__) . '/lib');
     $dotenv->load();
+    // PDOモックオブジェクトの作成
+    $this->pdo = $this->createMock(PDO::class);
+    $this->logAnalyses = new LogAnalyses();
   }
   public function testStart()
   {
-    $logAnalyses = new LogAnalyses();
-    $this->assertSame(1, $logAnalyses->start());
+    $this->assertTrue($this->logAnalyses->start());
   }
 
-
+  // 下記テストでは、モックを使用しているため、ConnectDb()のアクセス権をprotectedに変更する必要がある
   public function testConnectDb()
   {
-    // PDOオブジェクトのモックを作成
-    $pdoMock = $this->createMock(PDO::class);
-
-    // PDOモックにメソッドの返り値を設定
-    $pdoMock->method('setAttribute')->willReturn(true);
-
-    // クラスのインスタンス化
-    $database = $this->getMockBuilder(LogAnalyses::class)
-      ->onlyMethods(['connectDb'])
-      ->getMock();
-
+    // LogAnalysesオブジェクトの作成
+    $logAnalyses = $this->getMockBuilder(LogAnalyses::class)->onlyMethods(['connectDb'])->getMock();
     // connectDbメソッドのモック設定
-    $database->expects($this->once())
-      ->method('connectDb')
-      ->willReturn($pdoMock);
+    $logAnalyses->method('connectDb')->willReturn($this->pdo);
+    $reflection = new ReflectionClass($logAnalyses);
+    $method = $reflection->getMethod('connectDb');
+    $method->setAccessible(true);
+    // privateメソッドのテスト
+    $pdo = $method->invoke($logAnalyses);
+    $this->assertInstanceOf(PDO::class, $pdo);
+  }
 
-    // 実際にconnectDbメソッドを呼び出してテスト
-    $this->assertSame($pdoMock, $database->connectDb());
+  public function testSelectNumber()
+  {
+    $reflection = new ReflectionClass($this->logAnalyses);
+    $method = $reflection->getMethod('selectNumber');
+    $method->setAccessible(true);
+    // 標準入力iを入力
+    $inputNumber = $method->invoke($this->logAnalyses);
+    $this->assertSame(1, $inputNumber);
+    //　標準入力2を入力
+    $inputNumber = $method->invoke($this->logAnalyses);
+    $this->assertSame(2, $inputNumber);
+  }
+
+  public function testIsNotFloat()
+  {
+    $reflection = new ReflectionClass($this->logAnalyses);
+    $method = $reflection->getMethod('isNotFloat');
+    $method->setAccessible(true);
+    $output = $method->invoke($this->logAnalyses, 1);
+    $this->assertTrue($output);
+    $output = $method->invoke($this->logAnalyses, 1.5);
+    $this->assertFalse($output);
+  }
+
+  public function testIsOneOrTwo()
+  {
+    $reflection = new ReflectionClass($this->logAnalyses);
+    $method = $reflection->getMethod('isOneOrTwo');
+    $method->setAccessible(true);
+    $output = $method->invoke($this->logAnalyses, 1);
+    $this->assertTrue($output);
+    $output = $method->invoke($this->logAnalyses, 2);
+    $this->assertTrue($output);
+    $output = $method->invoke($this->logAnalyses, 3);
+    $this->assertFalse($output);
+  }
+
+  public function testGetProcessor()
+  {
+    $reflection = new ReflectionClass($this->logAnalyses);
+    $method = $reflection->getMethod('getProcessor');
+    $method->setAccessible(true);
+    $output = $method->invoke($this->logAnalyses, 1);
+    $this->assertSame(ViewCountProcessor::class, get_class($output));
+    $output = $method->invoke($this->logAnalyses, 2);
+    $this->assertSame(DomainViewProcessor::class, get_class($output));
   }
 }

--- a/src/src/tests/ViewCountProcessorTest.php
+++ b/src/src/tests/ViewCountProcessorTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace WikiLogs\Tests;
+
+use PHPUnit\Framework\TestCase;
+use WikiLogs\LogAnalyses;
+use WikiLogs\ViewCountProcessor;
+use Dotenv;
+use PDO;
+use ReflectionClass;
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+require_once __DIR__ . '/../lib/LogAnalyses.php';
+require_once __DIR__ . '/../lib/ViewCountProcessor.php';
+
+class ViewCountProcessorTest extends TestCase
+{
+  // PDOオブジェクトを格納するプロパティ
+  private $pdo;
+
+  public function setUp(): void
+  {
+    parent::setUp();
+    // .envファイルのロード
+    $dotenv = Dotenv\Dotenv::createImmutable(dirname(__DIR__) . '/lib');
+    $dotenv->load();
+    $logAnalyses = new LogAnalyses();
+    $reflection = new ReflectionClass($logAnalyses);
+    $method = $reflection->getMethod('connectDb');
+    $method->setAccessible(true);
+    $this->pdo = $method->invoke($logAnalyses);
+  }
+
+  public function testExecute()
+  {
+    $viewCountProcessor = new ViewCountProcessor();
+    ob_start();
+    $viewCountProcessor->execute($this->pdo);
+    $output = ob_get_clean();
+    $this->assertSame('表示させたい記事数の値(整数)を入力してください。' . PHP_EOL . '------------------------------' . PHP_EOL . 'en.m' . PHP_EOL . 'Main_Page' . PHP_EOL . '122058' . PHP_EOL . '------------------------------' . PHP_EOL, $output);
+  }
+
+  public function testGetArticleCount()
+  {
+    $viewCountProcessor = new ViewCountProcessor();
+    $reflection = new ReflectionClass($viewCountProcessor);
+    $method = $reflection->getMethod('getArticleCount');
+    $method->setAccessible(true);
+    $output = $method->invoke($viewCountProcessor);
+    // 標準入力の値を期待値として設定
+    $this->assertSame(1, $output);
+  }
+}


### PR DESCRIPTION
■ViewCountProcessor.php
・execute()
getArticleCount()による標準入力から、表示させたい記事数の整数を入力させます。
*getArticleCount()の処理では、whileによる無限ループを実装しており、1以上の整数を入力することで、ループを抜け出すよう実装しております。
execute()の引数として受け取ったPDOオブジェクトより、データベースから総閲覧数の多い順に入力された整数の数ほど
レコードを取得し、降順に表示させております。
