### PR TITLE
標準入力より取得したドメイン名ごとに、総閲覧数を表示する処理を実装しました。

### DIFF
--- a/src/phpunit.xml
+++ b/src/phpunit.xml
@@ -4,7 +4,8 @@
     <testsuite name="Tests">
       <!-- <directory>src/tests/</directory> -->
       <!-- <file>src/tests/ViewCountProcessorTest.php</file> -->
-      <file>src/tests/LogAnalysesTest.php</file>
+      <file>src/tests/DomainViewProcessorTest.php</file>
+      <!-- <file>src/tests/LogAnalysesTest.php</file> -->
     </testsuite>
   </testsuites>
 </phpunit>

--- a/src/sql.sql
+++ b/src/sql.sql
@@ -1,0 +1,7 @@
+SELECT
+  domain_name,
+  MAX(page_views) AS max_page_views
+FROM page_views
+WHERE domain_name IN ('de', 'en')
+GROUP BY domain_name
+ORDER BY max_page_views DESC;

--- a/src/src/lib/DomainViewProcessor.php
+++ b/src/src/lib/DomainViewProcessor.php
@@ -6,5 +6,47 @@ use PDO;
 
 class DomainViewProcessor extends Processor
 {
-  public function execute(PDO $pdo) {}
+  public function execute(PDO $pdo): void
+  {
+    $articleName = $this->getArticleName();
+    $domainsArray = explode(' ', $articleName);
+    // プレースホルダーを動的に生成
+    $placeHolders = implode(',', array_fill(0, count($domainsArray), '?'));
+    $statement = $pdo->prepare("SELECT domain_name, MAX(page_views) AS max_page_views FROM page_views WHERE domain_name IN ($placeHolders) GROUP BY domain_name ORDER BY max_page_views DESC");
+    foreach ($domainsArray as $index => $name) {
+      $statement->bindValue($index + 1, $name, PDO::PARAM_STR);
+    }
+    $statement->execute();
+
+    while ($rows = $statement->fetch(PDO::FETCH_ASSOC)) {
+      foreach ($rows as $row) {
+        echo $row . PHP_EOL;
+      }
+      echo '------------------------------' . PHP_EOL;
+    }
+  }
+
+  // 表示するドメイン名を標準入力より取得
+  private function getArticleName(): string
+  {
+    while (true) {
+      echo '表示させたいドメイン名を入力してください。(ドメイン名を半角スペースで区切ることで複数のドメイン名を入力可能です。)' . PHP_EOL;
+      echo '入力例） en de ja' . PHP_EOL;
+      echo '------------------------------' . PHP_EOL;
+      $articleName = trim(fgets(STDIN));
+      if ($this->isSpaceSeparated($articleName)) {
+        break;
+      } else {
+        echo 'Error:ドメイン名が半角スペースで区切られておりません。' . PHP_EOL;
+        echo 'ドメイン名は半角スペースで区切って入力してください。' . PHP_EOL;
+      }
+    }
+    return $articleName;
+  }
+
+  // 入力値された文字列が半角スペースで区切られているかを確認する処理
+  private function isSpaceSeparated($articleName): bool
+  {
+    return preg_match('/^[\S]+(?: [\S]+)*$/', $articleName);
+  }
 }

--- a/src/src/tests/DomainViewProcessorTest.php
+++ b/src/src/tests/DomainViewProcessorTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace WikiLogs\Tests;
+
+use PHPUnit\Framework\TestCase;
+use WikiLogs\LogAnalyses;
+use WikiLogs\DomainViewProcessor;
+use Dotenv;
+use PDO;
+use ReflectionClass;
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+require_once __DIR__ . '/../lib/LogAnalyses.php';
+require_once __DIR__ . '/../lib/DomainViewProcessor.php';
+
+class DomainViewProcessorTest extends TestCase
+{
+  // PDOオブジェクトを格納するプロパティ
+  private $pdo;
+
+  public function setUp(): void
+  {
+    parent::setUp();
+    // .envファイルのロード
+    $dotenv = Dotenv\Dotenv::createImmutable(dirname(__DIR__) . '/lib');
+    $dotenv->load();
+    $logAnalyses = new LogAnalyses();
+    $reflection = new ReflectionClass($logAnalyses);
+    $method = $reflection->getMethod('connectDb');
+    $method->setAccessible(true);
+    $this->pdo = $method->invoke($logAnalyses);
+  }
+
+  public function testExecute()
+  {
+    $domainViewProcessor = new DomainViewProcessor();
+    ob_start();
+    $domainViewProcessor->execute($this->pdo);
+    $output = ob_get_clean();
+    // 'en' を入力
+    $this->assertSame('表示させたいドメイン名を入力してください。(ドメイン名を半角スペースで区切ることで複数のドメイン名を入力可能です。)' . PHP_EOL . '入力例） en de ja' . PHP_EOL . '------------------------------' . PHP_EOL . 'en' . PHP_EOL . '69181' . PHP_EOL .  '------------------------------' . PHP_EOL, $output);
+  }
+
+  public function testGetArticleName()
+  {
+    $domainViewProcessor = new DomainViewProcessor();
+    $reflection = new ReflectionClass($domainViewProcessor);
+    $method = $reflection->getMethod('getArticleName');
+    $method->setAccessible(true);
+    $output = $method->invoke($domainViewProcessor);
+    // 標準入力の値を期待値として設定
+    $this->assertSame('en', $output);
+  }
+
+  public function testIsSpaceSeparated()
+  {
+    $domainViewProcessor = new DomainViewProcessor();
+    $reflection = new ReflectionClass($domainViewProcessor);
+    $method = $reflection->getMethod('isSpaceSeparated');
+    $method->setAccessible(true);
+    $output = $method->invoke($domainViewProcessor, 'en de');
+    $this->assertTrue($output);
+  }
+}


### PR DESCRIPTION
■DomainViewProcessor.php
・logAnalyses.phpのselectNumber()により2を入力した場合、getProcessor()にて取得したDomainViewProcessorオブジェクトのexecute()にて以下処理を実行するよう実装しました。

・execute()
以下処理を実装しております。
・getArticleName()
標準入力よりドメイン名を半角スペースで区切って入力((例）en de ja)し、$articleNameに格納します。

$articleNameの値を$domainsArrayに配列として格納します。
プレースホルダーを動的に生成するために$articleArrayの配列値を$placeHoldersに格納します。
PDOのprepare()によりクエリを$statementに格納します。
foreachのループ処理によりプレースホルダーに動的に$domainArrayの値をセットし、execute()にてクエリを実行します。

クエリの結果を$statement->fetch(PDO::FETCH_ASSOCにより取得し、コマンドライン上に表示させてます。